### PR TITLE
[mango/Week9] ProfileView 수정

### DIFF
--- a/mango/Megabox/Megabox.xcodeproj/project.pbxproj
+++ b/mango/Megabox/Megabox.xcodeproj/project.pbxproj
@@ -434,6 +434,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Megabox/Info.plist;
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 앨범 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -464,6 +465,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Megabox/Info.plist;
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진 앨범 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/mango/Megabox/Megabox/Features/Profile/ImagePicker.swift
+++ b/mango/Megabox/Megabox/Features/Profile/ImagePicker.swift
@@ -1,0 +1,55 @@
+//
+//  ImagePicker.swift
+//  Megabox
+//
+//  Created by 송민교 on 12/19/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+// Representable 프로토콜로 UIKit를 래핑
+struct ImagePicker: UIViewControllerRepresentable {
+    @Environment(\.dismiss) var dismiss
+    @Binding var image: UIImage
+    
+    // UIKit의 ViewController
+    func makeUIViewController(context: Context) -> PHPickerViewController{
+        var config = PHPickerConfiguration(photoLibrary: PHPhotoLibrary.shared())
+        config.selectionLimit = 1
+        config.filter = .images
+        
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+    
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context){}
+    
+    class Coordinator: NSObject, PHPickerViewControllerDelegate{
+        var parent: ImagePicker
+        
+        init(parent: ImagePicker){
+            self.parent = parent
+        }
+        
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]){
+            parent.dismiss()
+            
+            guard let provider = results.first?.itemProvider,
+                  provider.canLoadObject(ofClass: UIImage.self) else {return}
+            
+            provider.loadObject(ofClass: UIImage.self) { image, _ in
+                if let uiImage = image as? UIImage {
+                        DispatchQueue.main.async {
+                        self.parent.image = uiImage
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mango/Megabox/Megabox/Features/Profile/ProfileView.swift
+++ b/mango/Megabox/Megabox/Features/Profile/ProfileView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ProfileView: View {
+    @State private var showImagePicker = false
+    @State private var selectedImage: UIImage = UIImage(systemName: "person.circle.fill")!
     
     var body: some View {
         VStack(spacing:33){
@@ -23,21 +25,46 @@ struct ProfileView: View {
         }
         .frame(width: 380)
         .offset(y: -150) // 실제 레이아웃에는 그대로 두고 보이는 위치만 이동
+        .sheet(isPresented: $showImagePicker){
+            ImagePicker(image: $selectedImage)
+        }
     }
     
     private var profileHeader: some View {
         @AppStorage("userName") var userName = ""
         
-        return VStack(){
+        return VStack{
             HStack{
-                Text("\(userName)님")
-                    .font(.pretend(type: .bold, size: 24))
-                Text("WELCOME")
-                    .foregroundStyle(Color.white)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color(red: 0.28,green:0.8,blue:0.82))
-                    .cornerRadius(6)
+                Button(action:{
+                    showImagePicker = true
+                }){
+                    Image(uiImage: selectedImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 50, height: 50)
+                        .clipShape(Circle())
+                        .foregroundStyle(Color.gray)
+                }
+                
+                VStack(alignment:.leading){
+                    HStack{
+                        Text("\(userName)님")
+                            .font(.pretend(type: .bold, size: 24))
+                        Text("WELCOME")
+                            .foregroundStyle(Color.white)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color(red: 0.28,green:0.8,blue:0.82))
+                            .cornerRadius(6)
+                    }
+                    HStack{
+                        Text("멤버십 포인트")
+                            .foregroundStyle(Color.gray04)
+                            .font(.pretend(type: .semibold, size: 14))
+                        Text("500P")
+                            .font(.pretend(type: .medium, size: 14))
+                    }
+                }
                 
                 Spacer()
                 
@@ -50,14 +77,6 @@ struct ProfileView: View {
                 .background(Color.gray07)
                 .cornerRadius(16)
                 .frame(width: 72)
-            }
-            HStack{
-                Text("멤버십 포인트")
-                    .foregroundStyle(Color.gray04)
-                    .font(.pretend(type: .semibold, size: 14))
-                Text("500P")
-                    .font(.pretend(type: .medium, size: 14))
-                Spacer()
             }
         }
         .frame(maxWidth: .infinity)

--- a/mango/Megabox/Megabox/Info.plist
+++ b/mango/Megabox/Megabox/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>사진 앨범 접근 권한이 필요합니다.</string>
 	<key>API_KEY</key>
 	<string>2832400b12304cb1e98c8ada4b279582</string>
 	<key>CFBundleURLTypes</key>


### PR DESCRIPTION
## 주차별 학습내용 기록

> 작성자가 편한대로 주차별 학습한 내용을 기록해주세요

**[SwiftUI와 UIKit]**
- SwiftUI는 UIKit의 PHPickerViewController를 직접 활용할 수 없기 때문에 UIViewControllerRepresentable을 사용해서 래핑했다. (representable 프로토콜 사용)
- Representable의 구조 파악
1. makeUIViewController: UIKit 뷰를 초기화하고 생성
2. updateUIViewController: SwiftUI의 상태변화를 UIKit 뷰에 동기화
3. Coordinator로 UIKit의 delegate를 SwiftUI와 연결
- PhotosUI 프레임워크를 사용해서 단일 이미지를 선택하고 (PHPicker를 이용해 이미지 선택) @State변수에 저장하는 로직 구현

**[ProfileView 수정]**
- 프로필 아이콘 클릭 시 사진첩으르 띄우고(`sheet`) 선택한 이미지를 ProvileView에 반영

## 궁금한 점 & 스터디원들과 의논해보고 싶은 점

> 스터디 간 궁금한 점들에 대해서 작성해주세요.

- 사진첩에서 가져온 큰 사이즈의 UIImage를 앱 내에서 효율적으로 메모리를 관리하는 법이 있을까 궁금합니다.

## 체크리스트

- [x] 주차별 스터디 라벨을 할당했습니까?
- [x] 충돌문제를 해결했습니까?
- [x] PR 병합 방향을 확인했습니까? 작성자 본인의 `main` 브랜치로 병합하는 것을 확인했습니까?

## 시연 영상

> 시연 영상을 첨부해주세요!

https://github.com/user-attachments/assets/49272dcc-0a51-4704-8ed1-dfc1a8f82fbe

